### PR TITLE
Reserve configuration library + tests

### DIFF
--- a/contracts/protocol/libraries/configuration/reserve_configuration.cairo
+++ b/contracts/protocol/libraries/configuration/reserve_configuration.cairo
@@ -1,0 +1,544 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.math import assert_le
+
+@storage_var
+func ltv(reserve_asset : felt) -> (value : felt):
+end
+
+@storage_var
+func liquidation_threshold(reserve_asset : felt) -> (value : felt):
+end
+
+@storage_var
+func liquidation_bonus(reserve_asset : felt) -> (value : felt):
+end
+
+@storage_var
+func decimals(reserve_asset : felt) -> (value : felt):
+end
+
+@storage_var
+func reserve_active(reserve_asset : felt) -> (boolean : felt):
+end
+
+@storage_var
+func reserve_frozen(reserve_asset : felt) -> (boolean : felt):
+end
+
+@storage_var
+func borrowing_enabled(reserve_asset : felt) -> (boolean : felt):
+end
+
+@storage_var
+func stable_rate_borrowing_enabled(reserve_asset : felt) -> (boolean : felt):
+end
+
+@storage_var
+func asset_paused(reserve_asset : felt) -> (boolean : felt):
+end
+
+@storage_var
+func borrowable_in_isolation(reserve_asset : felt) -> (boolean : felt):
+end
+
+@storage_var
+func siloed_borrowing(reserve_asset : felt) -> (boolean : felt):
+end
+
+@storage_var
+func reserve_factor(reserve_asset : felt) -> (boolean : felt):
+end
+
+@storage_var
+func borrow_cap(reserve_asset : felt) -> (value : felt):
+end
+
+@storage_var
+func supply_cap(reserve_asset : felt) -> (value : felt):
+end
+
+@storage_var
+func liquidation_protocol_fee(reserve_asset : felt) -> (value : felt):
+end
+
+@storage_var
+func eMode_category(reserve_asset : felt) -> (value : felt):
+end
+
+@storage_var
+func unbacked_mint_cap(reserve_asset : felt) -> (value : felt):
+end
+
+@storage_var
+func debt_ceiling(reserve_asset : felt) -> (value : felt):
+end
+
+const MAX_VALID_LTV = 65535
+const MAX_VALID_LIQUIDATION_THRESHOLD = 65535
+const MAX_VALID_LIQUIDATION_BONUS = 65535
+const MAX_VALID_DECIMALS = 255
+const MAX_VALID_RESERVE_FACTOR = 65535
+const MAX_VALID_BORROW_CAP = 68719476735
+const MAX_VALID_SUPPLY_CAP = 68719476735
+const MAX_VALID_LIQUIDATION_PROTOCOL_FEE = 65535
+const MAX_VALID_EMODE_CATEGORY = 255
+const MAX_VALID_UNBACKED_MINT_CAP = 68719476735
+const MAX_VALID_DEBT_CEILING = 1099511627775
+
+const DEBT_CEILING_DECIMALS = 2
+const MAX_RESERVES_COUNT = 128
+
+namespace ReserveConfiguration:
+    const MAX_RESERVES_COUNT = 128
+
+    # @notice Sets the Loan to Value of the reserve
+    # @param value The new ltv
+    func set_ltv{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt, value : felt
+    ):
+        with_attr error_message("Invalid ltv parameter for the reserve"):
+            assert_le(value, MAX_VALID_LTV)
+        end
+        ltv.write(reserve_asset, value)
+        return ()
+    end
+
+    # @notice Gets the Loan to Value of the reserve
+    # @return The loan to value
+    func get_ltv{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (value : felt):
+        let (res) = ltv.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Sets the liquidation threshold of the reserve
+    # @param value The new liquidation threshold
+    func set_liquidation_threshold{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+    }(reserve_asset : felt, value : felt):
+        with_attr error_message("Invalid liquidity threshold parameter for the reserve"):
+            assert_le(value, MAX_VALID_LIQUIDATION_THRESHOLD)
+        end
+        liquidation_threshold.write(reserve_asset, value)
+        return ()
+    end
+
+    # @notice Gets the liquidation threshold of the reserve
+    # @return The liquidation threshold
+    func get_liquidation_threshold{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+    }(reserve_asset : felt) -> (value : felt):
+        let (res) = liquidation_threshold.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Sets the liquidation bonus of the reserve
+    # @param value The new liquidation bonus
+    func set_liquidation_bonus{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt, value : felt
+    ):
+        with_attr error_message("Invalid liquidity bonus parameter for the reserve"):
+            assert_le(value, MAX_VALID_LIQUIDATION_BONUS)
+        end
+        liquidation_bonus.write(reserve_asset, value)
+        return ()
+    end
+
+    # @notice Gets the liquidation bonus of the reserve
+    # @return The liquidation bonus
+    func get_liquidation_bonus{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (value : felt):
+        let (res) = liquidation_bonus.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Sets the decimals of the underlying asset of the reserve
+    # @param value The decimals
+    func set_decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt, value : felt
+    ):
+        with_attr error_message(
+                "Invalid decimals parameter of the underlying asset of the reserve"):
+            assert_le(value, MAX_VALID_DECIMALS)
+        end
+        decimals.write(reserve_asset, value)
+        return ()
+    end
+
+    # @notice Gets the decimals of the underlying asset of the reserve
+    # @return The decimals of the asset
+    func get_decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (value : felt):
+        let (res) = decimals.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Sets the active state of the reserve
+    # @param value The active state
+    func set_active{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt, value : felt
+    ):
+        # TODO after other branch merged, boolCompare.is_valid()
+        reserve_active.write(reserve_asset, value)
+        return ()
+    end
+
+    # @notice Gets the active state of the reserve
+    # @return The active state
+    func get_active{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (value : felt):
+        let (res) = reserve_active.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Sets the frozen state of the reserve
+    # @param value The frozen state
+    func set_frozen{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt, value : felt
+    ):
+        # TODO after other branch merged, boolCompare.is_valid()
+        reserve_frozen.write(reserve_asset, value)
+        return ()
+    end
+
+    # @notice Gets the frozen state of the reserve
+    # @return The frozen state
+    func get_frozen{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (value : felt):
+        let (res) = reserve_frozen.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Sets the paused state of the reserve
+    # @param value The paused state
+    func set_paused{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt, value : felt
+    ):
+        # TODO after other branch merged, boolCompare.is_valid()
+        asset_paused.write(reserve_asset, value)
+        return ()
+    end
+
+    # @notice Gets the paused state of the reserve
+    # @return The paused state
+    func get_paused{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (value : felt):
+        let (res) = asset_paused.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Sets the borrowable in isolation flag for the reserve.
+    # @dev When this flag is set to true, the asset will be borrowable against isolated collaterals and the borrowed
+    # amount will be accumulated in the isolated collateral's total debt exposure.
+    # @dev Only assets of the same family (eg USD stablecoins) should be borrowable in isolation mode to keep
+    # consistency in the debt ceiling calculations.
+    # @param borrowable True if the asset is borrowable
+    func set_borrowable_in_isolation{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+    }(reserve_asset : felt, borrowable : felt):
+        # TODO after other branch merged, boolCompare.is_valid()
+        borrowable_in_isolation.write(reserve_asset, borrowable)
+        return ()
+    end
+
+    # @notice Gets the borrowable in isolation flag for the reserve.
+    # @dev If the returned flag is true, the asset is borrowable against isolated collateral. Assets borrowed with
+    # isolated collateral is accounted for in the isolated collateral's total debt exposure.
+    # @dev Only assets of the same family (eg USD stablecoins) should be borrowable in isolation mode to keep
+    # consistency in the debt ceiling calculations.
+    # @return The borrowable in isolation flag
+    func get_borrowable_in_isolation{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+    }(reserve_asset : felt) -> (value : felt):
+        let (res) = borrowable_in_isolation.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Sets the siloed borrowing flag for the reserve.
+    # @dev When this flag is set to true, users borrowing this asset will not be allowed to borrow any other asset.
+    # @param siloed True if the asset is siloed
+    func set_siloed_borrowing{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt, siloed : felt
+    ):
+        # TODO after other branch merged, boolCompare.is_valid()
+        siloed_borrowing.write(reserve_asset, siloed)
+        return ()
+    end
+
+    # @notice Gets the siloed borrowing flag for the reserve.
+    # @dev When this flag is set to true, users borrowing this asset will not be allowed to borrow any other asset.
+    # @return The siloed borrowing flag
+    func get_siloed_borrowing{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (value : felt):
+        let (res) = siloed_borrowing.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Enables or disables borrowing on the reserve
+    # @param enabled True if the borrowing needs to be enabled, false otherwise
+    func set_borrowing_enabled{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt, enabled : felt
+    ):
+        # TODO after other branch merged, boolCompare.is_valid()
+        borrowing_enabled.write(reserve_asset, enabled)
+        return ()
+    end
+
+    # @notice Gets the borrowing state of the reserve
+    # @return The borrowing state
+    func get_borrowing_enabled{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (value : felt):
+        let (res) = borrowing_enabled.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Enables or disables stable rate borrowing on the reserve
+    # @param enabled True if the stable rate borrowing needs to be enabled, false otherwise
+    func set_stable_rate_borrowing_enabled{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+    }(reserve_asset : felt, enabled : felt):
+        # TODO after other branch merged, boolCompare.is_valid()
+        stable_rate_borrowing_enabled.write(reserve_asset, enabled)
+        return ()
+    end
+
+    # @notice Gets the stable rate borrowing state of the reserve
+    # @return The stable rate borrowing state
+    func get_stable_rate_borrowing_enabled{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+    }(reserve_asset : felt) -> (value : felt):
+        let (res) = stable_rate_borrowing_enabled.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Sets the reserve factor of the reserve
+    # @param reserveFactor The reserve factor
+    func set_reserve_factor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt, value : felt
+    ):
+        with_attr error_message("Invalid reserve factor parameter for the reserve"):
+            assert_le(value, MAX_VALID_RESERVE_FACTOR)
+        end
+        reserve_factor.write(reserve_asset, value)
+        return ()
+    end
+
+    # @notice Gets the reserve factor of the reserve
+    # @return The reserve factor
+    func get_reserve_factor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (value : felt):
+        let (res) = reserve_factor.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Sets the borrow cap of the reserve
+    # @param borrowCap The borrow cap
+
+    func set_borrow_cap{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt, value : felt
+    ):
+        with_attr error_message("Invalid borrow cap for the reserve"):
+            assert_le(value, MAX_VALID_BORROW_CAP)
+        end
+        borrow_cap.write(reserve_asset, value)
+        return ()
+    end
+
+    # @notice Gets the borrow cap of the reserve
+    # @return The borrow cap
+
+    func get_borrow_cap{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (value : felt):
+        let (res) = borrow_cap.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Sets the supply cap of the reserve
+    # @param supplyCap The supply cap
+
+    func set_supply_cap{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt, value : felt
+    ):
+        with_attr error_message("Invalid supply cap for the reserve"):
+            assert_le(value, MAX_VALID_SUPPLY_CAP)
+        end
+        supply_cap.write(reserve_asset, value)
+        return ()
+    end
+
+    # @notice Gets the supply cap of the reserve
+    # @return The supply cap
+
+    func get_supply_cap{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (value : felt):
+        let (res) = supply_cap.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Sets the debt ceiling in isolation mode for the asset
+    # @param ceiling The maximum debt ceiling for the asset
+    func set_debt_ceiling{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt, ceiling : felt
+    ):
+        with_attr error_message("Invalid debt ceiling for the reserve"):
+            assert_le(ceiling, MAX_VALID_DEBT_CEILING)
+        end
+        debt_ceiling.write(reserve_asset, ceiling)
+        return ()
+    end
+
+    # @notice Gets the debt ceiling for the asset if the asset is in isolation mode
+    # @return The debt ceiling (0 = isolation mode disabled)
+    func get_debt_ceiling{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (value : felt):
+        let (res) = debt_ceiling.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Sets the liquidation protocol fee of the reserve
+    # @param value The liquidation protocol fee
+    func set_liquidation_protocol_fee{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+    }(reserve_asset : felt, value : felt):
+        with_attr error_message("Invalid liquidation protocol fee for the reserve"):
+            assert_le(value, MAX_VALID_LIQUIDATION_PROTOCOL_FEE)
+        end
+        liquidation_protocol_fee.write(reserve_asset, value)
+        return ()
+    end
+
+    # @dev Gets the liquidation protocol fee
+    # @return The liquidation protocol fee
+    func get_liquidation_protocol_fee{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+    }(reserve_asset : felt) -> (value : felt):
+        let (res) = liquidation_protocol_fee.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Sets the unbacked mint cap of the reserve
+    # @param value The unbacked mint cap
+    func set_unbacked_mint_cap{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt, value : felt
+    ):
+        with_attr error_message("Invalid unbacked mint cap for the reserve"):
+            assert_le(value, MAX_VALID_UNBACKED_MINT_CAP)
+        end
+        unbacked_mint_cap.write(reserve_asset, value)
+        return ()
+    end
+
+    # @dev Gets the unbacked mint cap of the reserve
+    # @return The unbacked mint cap
+    func get_unbacked_mint_cap{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (value : felt):
+        let (res) = unbacked_mint_cap.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Sets the eMode asset category
+    # @param category The asset category when the user selects the eMode
+    func set_eMode_category{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt, category : felt
+    ):
+        with_attr error_message("Invalid eMode category for the reserve"):
+            assert_le(category, MAX_VALID_EMODE_CATEGORY)
+        end
+        eMode_category.write(reserve_asset, category)
+        return ()
+    end
+
+    # @dev Gets the eMode asset category
+    # @return The eMode category for the asset
+    func get_eMode_category{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (value : felt):
+        let (res) = eMode_category.read(reserve_asset)
+        return (res)
+    end
+
+    # @notice Gets the configuration flags of the reserve
+    # @return The state flag representing active
+    # @return The state flag representing frozen
+    # @return The state flag representing borrowing enabled
+    # @return The state flag representing stableRateBorrowing enabled
+    # @return The state flag representing paused
+    func get_flags{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (
+        is_active : felt,
+        is_frozen : felt,
+        is_borrowing_enabled : felt,
+        is_stable_rate_borrowing_enabled : felt,
+        is_paused : felt,
+    ):
+        let (is_active) = reserve_active.read(reserve_asset)
+        let (is_frozen) = reserve_frozen.read(reserve_asset)
+        let (is_borrowing_enabled) = borrowing_enabled.read(reserve_asset)
+        let (is_stable_rate_borrowing_enabled) = stable_rate_borrowing_enabled.read(reserve_asset)
+        let (is_paused) = asset_paused.read(reserve_asset)
+
+        return (
+            is_active, is_frozen, is_borrowing_enabled, is_stable_rate_borrowing_enabled, is_paused
+        )
+    end
+
+    # @notice Gets the configuration parameters of the reserve from storage
+    # @return The state param representing ltv
+    # @return The state param representing liquidation threshold
+    # @return The state param representing liquidation bonus
+    # @return The state param representing reserve decimals
+    # @return The state param representing reserve factor
+    # @return The state param representing eMode category
+    func get_params{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (
+        ltv_value : felt,
+        liquidation_threshold_value : felt,
+        liquidation_bonus_value : felt,
+        decimals_value : felt,
+        reserve_factor_value : felt,
+        eMode_category_value : felt,
+    ):
+        let (ltv_value) = ltv.read(reserve_asset)
+        let (liquidation_threshold_value) = liquidation_threshold.read(reserve_asset)
+        let (liquidation_bonus_value) = liquidation_bonus.read(reserve_asset)
+        let (decimals_value) = decimals.read(reserve_asset)
+        let (reserve_factor_value) = reserve_factor.read(reserve_asset)
+        let (eMode_category_value) = eMode_category.read(reserve_asset)
+        return (
+            ltv_value,
+            liquidation_threshold_value,
+            liquidation_bonus_value,
+            decimals_value,
+            reserve_factor_value,
+            eMode_category_value,
+        )
+    end
+
+    # @notice Gets the caps parameters of the reserve from storage
+    # @return The state param representing borrow cap
+    # @return The state param representing supply cap.
+    func get_caps{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        reserve_asset : felt
+    ) -> (borrow_cap : felt, supply_cap : felt):
+        let (borrow_cap_value) = borrow_cap.read(reserve_asset)
+        let (supply_cap_value) = supply_cap.read(reserve_asset)
+        return (borrow_cap_value, supply_cap_value)
+    end
+end

--- a/contracts/protocol/libraries/configuration/reserve_configuration.cairo
+++ b/contracts/protocol/libraries/configuration/reserve_configuration.cairo
@@ -6,75 +6,75 @@ from starkware.cairo.common.math import assert_le
 from contracts.protocol.libraries.helpers.bool_cmp import BoolCompare
 
 @storage_var
-func ltv(reserve_asset : felt) -> (value : felt):
+func ReserveConfiguration_ltv(reserve_asset : felt) -> (value : felt):
 end
 
 @storage_var
-func liquidation_threshold(reserve_asset : felt) -> (value : felt):
+func ReserveConfiguration_liquidation_threshold(reserve_asset : felt) -> (value : felt):
 end
 
 @storage_var
-func liquidation_bonus(reserve_asset : felt) -> (value : felt):
+func ReserveConfiguration_liquidation_bonus(reserve_asset : felt) -> (value : felt):
 end
 
 @storage_var
-func decimals(reserve_asset : felt) -> (value : felt):
+func ReserveConfiguration_decimals(reserve_asset : felt) -> (value : felt):
 end
 
 @storage_var
-func reserve_active(reserve_asset : felt) -> (boolean : felt):
+func ReserveConfiguration_reserve_active(reserve_asset : felt) -> (boolean : felt):
 end
 
 @storage_var
-func reserve_frozen(reserve_asset : felt) -> (boolean : felt):
+func ReserveConfiguration_reserve_frozen(reserve_asset : felt) -> (boolean : felt):
 end
 
 @storage_var
-func borrowing_enabled(reserve_asset : felt) -> (boolean : felt):
+func ReserveConfiguration_borrowing_enabled(reserve_asset : felt) -> (boolean : felt):
 end
 
 @storage_var
-func stable_rate_borrowing_enabled(reserve_asset : felt) -> (boolean : felt):
+func ReserveConfiguration_stable_rate_borrowing_enabled(reserve_asset : felt) -> (boolean : felt):
 end
 
 @storage_var
-func asset_paused(reserve_asset : felt) -> (boolean : felt):
+func ReserveConfiguration_asset_paused(reserve_asset : felt) -> (boolean : felt):
 end
 
 @storage_var
-func borrowable_in_isolation(reserve_asset : felt) -> (boolean : felt):
+func ReserveConfiguration_borrowable_in_isolation(reserve_asset : felt) -> (boolean : felt):
 end
 
 @storage_var
-func siloed_borrowing(reserve_asset : felt) -> (boolean : felt):
+func ReserveConfiguration_siloed_borrowing(reserve_asset : felt) -> (boolean : felt):
 end
 
 @storage_var
-func reserve_factor(reserve_asset : felt) -> (boolean : felt):
+func ReserveConfiguration_reserve_factor(reserve_asset : felt) -> (boolean : felt):
 end
 
 @storage_var
-func borrow_cap(reserve_asset : felt) -> (value : felt):
+func ReserveConfiguration_borrow_cap(reserve_asset : felt) -> (value : felt):
 end
 
 @storage_var
-func supply_cap(reserve_asset : felt) -> (value : felt):
+func ReserveConfiguration_supply_cap(reserve_asset : felt) -> (value : felt):
 end
 
 @storage_var
-func liquidation_protocol_fee(reserve_asset : felt) -> (value : felt):
+func ReserveConfiguration_liquidation_protocol_fee(reserve_asset : felt) -> (value : felt):
 end
 
 @storage_var
-func eMode_category(reserve_asset : felt) -> (value : felt):
+func ReserveConfiguration_eMode_category(reserve_asset : felt) -> (value : felt):
 end
 
 @storage_var
-func unbacked_mint_cap(reserve_asset : felt) -> (value : felt):
+func ReserveConfiguration_unbacked_mint_cap(reserve_asset : felt) -> (value : felt):
 end
 
 @storage_var
-func debt_ceiling(reserve_asset : felt) -> (value : felt):
+func ReserveConfiguration_debt_ceiling(reserve_asset : felt) -> (value : felt):
 end
 
 const MAX_VALID_LTV = 65535
@@ -101,7 +101,7 @@ namespace ReserveConfiguration:
         with_attr error_message("Invalid ltv parameter for the reserve"):
             assert_le(value, MAX_VALID_LTV)
         end
-        ltv.write(reserve_asset, value)
+        ReserveConfiguration_ltv.write(reserve_asset, value)
         return ()
     end
 
@@ -110,7 +110,7 @@ namespace ReserveConfiguration:
     func get_ltv{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt
     ) -> (value : felt):
-        let (res) = ltv.read(reserve_asset)
+        let (res) = ReserveConfiguration_ltv.read(reserve_asset)
         return (res)
     end
 
@@ -122,7 +122,7 @@ namespace ReserveConfiguration:
         with_attr error_message("Invalid liquidity threshold parameter for the reserve"):
             assert_le(value, MAX_VALID_LIQUIDATION_THRESHOLD)
         end
-        liquidation_threshold.write(reserve_asset, value)
+        ReserveConfiguration_liquidation_threshold.write(reserve_asset, value)
         return ()
     end
 
@@ -131,7 +131,7 @@ namespace ReserveConfiguration:
     func get_liquidation_threshold{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
     }(reserve_asset : felt) -> (value : felt):
-        let (res) = liquidation_threshold.read(reserve_asset)
+        let (res) = ReserveConfiguration_liquidation_threshold.read(reserve_asset)
         return (res)
     end
 
@@ -143,7 +143,7 @@ namespace ReserveConfiguration:
         with_attr error_message("Invalid liquidity bonus parameter for the reserve"):
             assert_le(value, MAX_VALID_LIQUIDATION_BONUS)
         end
-        liquidation_bonus.write(reserve_asset, value)
+        ReserveConfiguration_liquidation_bonus.write(reserve_asset, value)
         return ()
     end
 
@@ -152,7 +152,7 @@ namespace ReserveConfiguration:
     func get_liquidation_bonus{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt
     ) -> (value : felt):
-        let (res) = liquidation_bonus.read(reserve_asset)
+        let (res) = ReserveConfiguration_liquidation_bonus.read(reserve_asset)
         return (res)
     end
 
@@ -165,7 +165,7 @@ namespace ReserveConfiguration:
                 "Invalid decimals parameter of the underlying asset of the reserve"):
             assert_le(value, MAX_VALID_DECIMALS)
         end
-        decimals.write(reserve_asset, value)
+        ReserveConfiguration_decimals.write(reserve_asset, value)
         return ()
     end
 
@@ -174,7 +174,7 @@ namespace ReserveConfiguration:
     func get_decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt
     ) -> (value : felt):
-        let (res) = decimals.read(reserve_asset)
+        let (res) = ReserveConfiguration_decimals.read(reserve_asset)
         return (res)
     end
 
@@ -184,7 +184,7 @@ namespace ReserveConfiguration:
         reserve_asset : felt, active : felt
     ):
         BoolCompare.is_valid(active)
-        reserve_active.write(reserve_asset, active)
+        ReserveConfiguration_reserve_active.write(reserve_asset, active)
         return ()
     end
 
@@ -193,7 +193,7 @@ namespace ReserveConfiguration:
     func get_active{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt
     ) -> (value : felt):
-        let (res) = reserve_active.read(reserve_asset)
+        let (res) = ReserveConfiguration_reserve_active.read(reserve_asset)
         return (res)
     end
 
@@ -203,7 +203,7 @@ namespace ReserveConfiguration:
         reserve_asset : felt, frozen : felt
     ):
         BoolCompare.is_valid(frozen)
-        reserve_frozen.write(reserve_asset, frozen)
+        ReserveConfiguration_reserve_frozen.write(reserve_asset, frozen)
         return ()
     end
 
@@ -212,7 +212,7 @@ namespace ReserveConfiguration:
     func get_frozen{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt
     ) -> (value : felt):
-        let (res) = reserve_frozen.read(reserve_asset)
+        let (res) = ReserveConfiguration_reserve_frozen.read(reserve_asset)
         return (res)
     end
 
@@ -222,7 +222,7 @@ namespace ReserveConfiguration:
         reserve_asset : felt, paused : felt
     ):
         BoolCompare.is_valid(paused)
-        asset_paused.write(reserve_asset, paused)
+        ReserveConfiguration_asset_paused.write(reserve_asset, paused)
         return ()
     end
 
@@ -231,7 +231,7 @@ namespace ReserveConfiguration:
     func get_paused{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt
     ) -> (value : felt):
-        let (res) = asset_paused.read(reserve_asset)
+        let (res) = ReserveConfiguration_asset_paused.read(reserve_asset)
         return (res)
     end
 
@@ -245,7 +245,7 @@ namespace ReserveConfiguration:
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
     }(reserve_asset : felt, borrowable : felt):
         BoolCompare.is_valid(borrowable)
-        borrowable_in_isolation.write(reserve_asset, borrowable)
+        ReserveConfiguration_borrowable_in_isolation.write(reserve_asset, borrowable)
         return ()
     end
 
@@ -258,7 +258,7 @@ namespace ReserveConfiguration:
     func get_borrowable_in_isolation{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
     }(reserve_asset : felt) -> (value : felt):
-        let (res) = borrowable_in_isolation.read(reserve_asset)
+        let (res) = ReserveConfiguration_borrowable_in_isolation.read(reserve_asset)
         return (res)
     end
 
@@ -269,7 +269,7 @@ namespace ReserveConfiguration:
         reserve_asset : felt, siloed : felt
     ):
         BoolCompare.is_valid(siloed)
-        siloed_borrowing.write(reserve_asset, siloed)
+        ReserveConfiguration_siloed_borrowing.write(reserve_asset, siloed)
         return ()
     end
 
@@ -279,7 +279,7 @@ namespace ReserveConfiguration:
     func get_siloed_borrowing{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt
     ) -> (value : felt):
-        let (res) = siloed_borrowing.read(reserve_asset)
+        let (res) = ReserveConfiguration_siloed_borrowing.read(reserve_asset)
         return (res)
     end
 
@@ -289,7 +289,7 @@ namespace ReserveConfiguration:
         reserve_asset : felt, enabled : felt
     ):
         BoolCompare.is_valid(enabled)
-        borrowing_enabled.write(reserve_asset, enabled)
+        ReserveConfiguration_borrowing_enabled.write(reserve_asset, enabled)
         return ()
     end
 
@@ -298,7 +298,7 @@ namespace ReserveConfiguration:
     func get_borrowing_enabled{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt
     ) -> (value : felt):
-        let (res) = borrowing_enabled.read(reserve_asset)
+        let (res) = ReserveConfiguration_borrowing_enabled.read(reserve_asset)
         return (res)
     end
 
@@ -308,7 +308,7 @@ namespace ReserveConfiguration:
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
     }(reserve_asset : felt, enabled : felt):
         BoolCompare.is_valid(enabled)
-        stable_rate_borrowing_enabled.write(reserve_asset, enabled)
+        ReserveConfiguration_stable_rate_borrowing_enabled.write(reserve_asset, enabled)
         return ()
     end
 
@@ -317,7 +317,7 @@ namespace ReserveConfiguration:
     func get_stable_rate_borrowing_enabled{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
     }(reserve_asset : felt) -> (value : felt):
-        let (res) = stable_rate_borrowing_enabled.read(reserve_asset)
+        let (res) = ReserveConfiguration_stable_rate_borrowing_enabled.read(reserve_asset)
         return (res)
     end
 
@@ -329,7 +329,7 @@ namespace ReserveConfiguration:
         with_attr error_message("Invalid reserve factor parameter for the reserve"):
             assert_le(value, MAX_VALID_RESERVE_FACTOR)
         end
-        reserve_factor.write(reserve_asset, value)
+        ReserveConfiguration_reserve_factor.write(reserve_asset, value)
         return ()
     end
 
@@ -338,7 +338,7 @@ namespace ReserveConfiguration:
     func get_reserve_factor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt
     ) -> (value : felt):
-        let (res) = reserve_factor.read(reserve_asset)
+        let (res) = ReserveConfiguration_reserve_factor.read(reserve_asset)
         return (res)
     end
 
@@ -351,7 +351,7 @@ namespace ReserveConfiguration:
         with_attr error_message("Invalid borrow cap for the reserve"):
             assert_le(value, MAX_VALID_BORROW_CAP)
         end
-        borrow_cap.write(reserve_asset, value)
+        ReserveConfiguration_borrow_cap.write(reserve_asset, value)
         return ()
     end
 
@@ -361,7 +361,7 @@ namespace ReserveConfiguration:
     func get_borrow_cap{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt
     ) -> (value : felt):
-        let (res) = borrow_cap.read(reserve_asset)
+        let (res) = ReserveConfiguration_borrow_cap.read(reserve_asset)
         return (res)
     end
 
@@ -374,7 +374,7 @@ namespace ReserveConfiguration:
         with_attr error_message("Invalid supply cap for the reserve"):
             assert_le(value, MAX_VALID_SUPPLY_CAP)
         end
-        supply_cap.write(reserve_asset, value)
+        ReserveConfiguration_supply_cap.write(reserve_asset, value)
         return ()
     end
 
@@ -384,7 +384,7 @@ namespace ReserveConfiguration:
     func get_supply_cap{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt
     ) -> (value : felt):
-        let (res) = supply_cap.read(reserve_asset)
+        let (res) = ReserveConfiguration_supply_cap.read(reserve_asset)
         return (res)
     end
 
@@ -396,7 +396,7 @@ namespace ReserveConfiguration:
         with_attr error_message("Invalid debt ceiling for the reserve"):
             assert_le(ceiling, MAX_VALID_DEBT_CEILING)
         end
-        debt_ceiling.write(reserve_asset, ceiling)
+        ReserveConfiguration_debt_ceiling.write(reserve_asset, ceiling)
         return ()
     end
 
@@ -405,7 +405,7 @@ namespace ReserveConfiguration:
     func get_debt_ceiling{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt
     ) -> (value : felt):
-        let (res) = debt_ceiling.read(reserve_asset)
+        let (res) = ReserveConfiguration_debt_ceiling.read(reserve_asset)
         return (res)
     end
 
@@ -417,7 +417,7 @@ namespace ReserveConfiguration:
         with_attr error_message("Invalid liquidation protocol fee for the reserve"):
             assert_le(value, MAX_VALID_LIQUIDATION_PROTOCOL_FEE)
         end
-        liquidation_protocol_fee.write(reserve_asset, value)
+        ReserveConfiguration_liquidation_protocol_fee.write(reserve_asset, value)
         return ()
     end
 
@@ -426,7 +426,7 @@ namespace ReserveConfiguration:
     func get_liquidation_protocol_fee{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
     }(reserve_asset : felt) -> (value : felt):
-        let (res) = liquidation_protocol_fee.read(reserve_asset)
+        let (res) = ReserveConfiguration_liquidation_protocol_fee.read(reserve_asset)
         return (res)
     end
 
@@ -438,7 +438,7 @@ namespace ReserveConfiguration:
         with_attr error_message("Invalid unbacked mint cap for the reserve"):
             assert_le(value, MAX_VALID_UNBACKED_MINT_CAP)
         end
-        unbacked_mint_cap.write(reserve_asset, value)
+        ReserveConfiguration_unbacked_mint_cap.write(reserve_asset, value)
         return ()
     end
 
@@ -447,7 +447,7 @@ namespace ReserveConfiguration:
     func get_unbacked_mint_cap{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt
     ) -> (value : felt):
-        let (res) = unbacked_mint_cap.read(reserve_asset)
+        let (res) = ReserveConfiguration_unbacked_mint_cap.read(reserve_asset)
         return (res)
     end
 
@@ -459,7 +459,7 @@ namespace ReserveConfiguration:
         with_attr error_message("Invalid eMode category for the reserve"):
             assert_le(category, MAX_VALID_EMODE_CATEGORY)
         end
-        eMode_category.write(reserve_asset, category)
+        ReserveConfiguration_eMode_category.write(reserve_asset, category)
         return ()
     end
 
@@ -468,7 +468,7 @@ namespace ReserveConfiguration:
     func get_eMode_category{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt
     ) -> (value : felt):
-        let (res) = eMode_category.read(reserve_asset)
+        let (res) = ReserveConfiguration_eMode_category.read(reserve_asset)
         return (res)
     end
 
@@ -487,11 +487,13 @@ namespace ReserveConfiguration:
         is_stable_rate_borrowing_enabled : felt,
         is_paused : felt,
     ):
-        let (is_active) = reserve_active.read(reserve_asset)
-        let (is_frozen) = reserve_frozen.read(reserve_asset)
-        let (is_borrowing_enabled) = borrowing_enabled.read(reserve_asset)
-        let (is_stable_rate_borrowing_enabled) = stable_rate_borrowing_enabled.read(reserve_asset)
-        let (is_paused) = asset_paused.read(reserve_asset)
+        let (is_active) = ReserveConfiguration_reserve_active.read(reserve_asset)
+        let (is_frozen) = ReserveConfiguration_reserve_frozen.read(reserve_asset)
+        let (is_borrowing_enabled) = ReserveConfiguration_borrowing_enabled.read(reserve_asset)
+        let (
+            is_stable_rate_borrowing_enabled
+        ) = ReserveConfiguration_stable_rate_borrowing_enabled.read(reserve_asset)
+        let (is_paused) = ReserveConfiguration_asset_paused.read(reserve_asset)
 
         return (
             is_active, is_frozen, is_borrowing_enabled, is_stable_rate_borrowing_enabled, is_paused
@@ -515,12 +517,14 @@ namespace ReserveConfiguration:
         reserve_factor_value : felt,
         eMode_category_value : felt,
     ):
-        let (ltv_value) = ltv.read(reserve_asset)
-        let (liquidation_threshold_value) = liquidation_threshold.read(reserve_asset)
-        let (liquidation_bonus_value) = liquidation_bonus.read(reserve_asset)
-        let (decimals_value) = decimals.read(reserve_asset)
-        let (reserve_factor_value) = reserve_factor.read(reserve_asset)
-        let (eMode_category_value) = eMode_category.read(reserve_asset)
+        let (ltv_value) = ReserveConfiguration_ltv.read(reserve_asset)
+        let (liquidation_threshold_value) = ReserveConfiguration_liquidation_threshold.read(
+            reserve_asset
+        )
+        let (liquidation_bonus_value) = ReserveConfiguration_liquidation_bonus.read(reserve_asset)
+        let (decimals_value) = ReserveConfiguration_decimals.read(reserve_asset)
+        let (reserve_factor_value) = ReserveConfiguration_reserve_factor.read(reserve_asset)
+        let (eMode_category_value) = ReserveConfiguration_eMode_category.read(reserve_asset)
         return (
             ltv_value,
             liquidation_threshold_value,
@@ -537,8 +541,8 @@ namespace ReserveConfiguration:
     func get_caps{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt
     ) -> (borrow_cap : felt, supply_cap : felt):
-        let (borrow_cap_value) = borrow_cap.read(reserve_asset)
-        let (supply_cap_value) = supply_cap.read(reserve_asset)
+        let (borrow_cap_value) = ReserveConfiguration_borrow_cap.read(reserve_asset)
+        let (supply_cap_value) = ReserveConfiguration_supply_cap.read(reserve_asset)
         return (borrow_cap_value, supply_cap_value)
     end
 end

--- a/contracts/protocol/libraries/configuration/reserve_configuration.cairo
+++ b/contracts/protocol/libraries/configuration/reserve_configuration.cairo
@@ -3,6 +3,8 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.math import assert_le
 
+from contracts.protocol.libraries.helpers.bool_cmp import BoolCompare
+
 @storage_var
 func ltv(reserve_asset : felt) -> (value : felt):
 end
@@ -87,10 +89,8 @@ const MAX_VALID_EMODE_CATEGORY = 255
 const MAX_VALID_UNBACKED_MINT_CAP = 68719476735
 const MAX_VALID_DEBT_CEILING = 1099511627775
 
-const DEBT_CEILING_DECIMALS = 2
-const MAX_RESERVES_COUNT = 128
-
 namespace ReserveConfiguration:
+    const DEBT_CEILING_DECIMALS = 2
     const MAX_RESERVES_COUNT = 128
 
     # @notice Sets the Loan to Value of the reserve
@@ -179,12 +179,12 @@ namespace ReserveConfiguration:
     end
 
     # @notice Sets the active state of the reserve
-    # @param value The active state
+    # @param active The active state
     func set_active{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        reserve_asset : felt, value : felt
+        reserve_asset : felt, active : felt
     ):
-        # TODO after other branch merged, boolCompare.is_valid()
-        reserve_active.write(reserve_asset, value)
+        BoolCompare.is_valid(active)
+        reserve_active.write(reserve_asset, active)
         return ()
     end
 
@@ -198,12 +198,12 @@ namespace ReserveConfiguration:
     end
 
     # @notice Sets the frozen state of the reserve
-    # @param value The frozen state
+    # @param frozen The frozen state
     func set_frozen{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        reserve_asset : felt, value : felt
+        reserve_asset : felt, frozen : felt
     ):
-        # TODO after other branch merged, boolCompare.is_valid()
-        reserve_frozen.write(reserve_asset, value)
+        BoolCompare.is_valid(frozen)
+        reserve_frozen.write(reserve_asset, frozen)
         return ()
     end
 
@@ -219,10 +219,10 @@ namespace ReserveConfiguration:
     # @notice Sets the paused state of the reserve
     # @param value The paused state
     func set_paused{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        reserve_asset : felt, value : felt
+        reserve_asset : felt, paused : felt
     ):
-        # TODO after other branch merged, boolCompare.is_valid()
-        asset_paused.write(reserve_asset, value)
+        BoolCompare.is_valid(paused)
+        asset_paused.write(reserve_asset, paused)
         return ()
     end
 
@@ -244,7 +244,7 @@ namespace ReserveConfiguration:
     func set_borrowable_in_isolation{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
     }(reserve_asset : felt, borrowable : felt):
-        # TODO after other branch merged, boolCompare.is_valid()
+        BoolCompare.is_valid(borrowable)
         borrowable_in_isolation.write(reserve_asset, borrowable)
         return ()
     end
@@ -268,7 +268,7 @@ namespace ReserveConfiguration:
     func set_siloed_borrowing{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt, siloed : felt
     ):
-        # TODO after other branch merged, boolCompare.is_valid()
+        BoolCompare.is_valid(siloed)
         siloed_borrowing.write(reserve_asset, siloed)
         return ()
     end
@@ -288,7 +288,7 @@ namespace ReserveConfiguration:
     func set_borrowing_enabled{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt, enabled : felt
     ):
-        # TODO after other branch merged, boolCompare.is_valid()
+        BoolCompare.is_valid(enabled)
         borrowing_enabled.write(reserve_asset, enabled)
         return ()
     end
@@ -307,7 +307,7 @@ namespace ReserveConfiguration:
     func set_stable_rate_borrowing_enabled{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
     }(reserve_asset : felt, enabled : felt):
-        # TODO after other branch merged, boolCompare.is_valid()
+        BoolCompare.is_valid(enabled)
         stable_rate_borrowing_enabled.write(reserve_asset, enabled)
         return ()
     end

--- a/contracts/protocol/libraries/configuration/reserve_configuration.cairo
+++ b/contracts/protocol/libraries/configuration/reserve_configuration.cairo
@@ -94,6 +94,7 @@ namespace ReserveConfiguration:
     const MAX_RESERVES_COUNT = 128
 
     # @notice Sets the Loan to Value of the reserve
+    # @param reserve_asset underlying asset of the reserve
     # @param value The new ltv
     func set_ltv{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         reserve_asset : felt, value : felt

--- a/tests/unit_tests/protocol/libraries/configuration/test_reserve_configuration.cairo
+++ b/tests/unit_tests/protocol/libraries/configuration/test_reserve_configuration.cairo
@@ -1,0 +1,190 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+from contracts.protocol.libraries.configuration.reserve_configuration import ReserveConfiguration
+
+const TEST_RESERVE_ASSET = 101928301924019284
+
+@external
+func test_ltv{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    ReserveConfiguration.set_ltv(TEST_RESERVE_ASSET, 10)
+    let (ltv) = ReserveConfiguration.get_ltv(TEST_RESERVE_ASSET)
+    assert ltv = 10
+    return ()
+end
+
+@external
+func test_liquidation_threshold{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    ):
+    ReserveConfiguration.set_liquidation_threshold(TEST_RESERVE_ASSET, 10)
+    let (liquidation_threshold) = ReserveConfiguration.get_liquidation_threshold(TEST_RESERVE_ASSET)
+    assert liquidation_threshold = 10
+    return ()
+end
+
+@external
+func test_liquidation_bonus{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    ReserveConfiguration.set_liquidation_bonus(TEST_RESERVE_ASSET, 10)
+    let (liquidation_bonus) = ReserveConfiguration.get_liquidation_bonus(TEST_RESERVE_ASSET)
+    assert liquidation_bonus = 10
+    return ()
+end
+
+@external
+func test_decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    ReserveConfiguration.set_decimals(TEST_RESERVE_ASSET, 10)
+    let (decimals) = ReserveConfiguration.get_decimals(TEST_RESERVE_ASSET)
+    assert decimals = 10
+    return ()
+end
+
+@external
+func test_active{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    ReserveConfiguration.set_active(TEST_RESERVE_ASSET, 1)
+    let (active) = ReserveConfiguration.get_active(TEST_RESERVE_ASSET)
+    assert active = 1
+    return ()
+end
+
+@external
+func test_frozen{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    ReserveConfiguration.set_frozen(TEST_RESERVE_ASSET, 1)
+    let (frozen) = ReserveConfiguration.get_frozen(TEST_RESERVE_ASSET)
+    assert frozen = 1
+    return ()
+end
+
+@external
+func test_paused{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    ReserveConfiguration.set_paused(TEST_RESERVE_ASSET, 1)
+    let (paused) = ReserveConfiguration.get_paused(TEST_RESERVE_ASSET)
+    assert paused = 1
+    return ()
+end
+
+@external
+func test_borrowable_in_isolation{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+}():
+    ReserveConfiguration.set_borrowable_in_isolation(TEST_RESERVE_ASSET, 1)
+    let (borrowable_in_isolation) = ReserveConfiguration.get_borrowable_in_isolation(
+        TEST_RESERVE_ASSET
+    )
+    assert borrowable_in_isolation = 1
+    return ()
+end
+
+@external
+func test_siloed_borrowing{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    ReserveConfiguration.set_siloed_borrowing(TEST_RESERVE_ASSET, 1)
+    let (siloed_borrowing) = ReserveConfiguration.get_siloed_borrowing(TEST_RESERVE_ASSET)
+    assert siloed_borrowing = 1
+    return ()
+end
+
+@external
+func test_borrow_cap{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    ReserveConfiguration.set_borrow_cap(TEST_RESERVE_ASSET, 10)
+    let (borrow_cap) = ReserveConfiguration.get_borrow_cap(TEST_RESERVE_ASSET)
+    assert borrow_cap = 10
+    return ()
+end
+
+@external
+func test_supply_cap{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    ReserveConfiguration.set_supply_cap(TEST_RESERVE_ASSET, 10)
+    let (supply_cap) = ReserveConfiguration.get_supply_cap(TEST_RESERVE_ASSET)
+    assert supply_cap = 10
+    return ()
+end
+
+@external
+func test_debt_ceiling{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    ReserveConfiguration.set_debt_ceiling(TEST_RESERVE_ASSET, 10)
+    let (debt_ceiling) = ReserveConfiguration.get_debt_ceiling(TEST_RESERVE_ASSET)
+    assert debt_ceiling = 10
+    return ()
+end
+
+@external
+func test_liquidation_protocol_fee{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+}():
+    ReserveConfiguration.set_liquidation_protocol_fee(TEST_RESERVE_ASSET, 10)
+    let (liquidation_protocol_fee) = ReserveConfiguration.get_liquidation_protocol_fee(
+        TEST_RESERVE_ASSET
+    )
+    assert liquidation_protocol_fee = 10
+    return ()
+end
+
+@external
+func test_unbacked_mint_cap{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    ReserveConfiguration.set_unbacked_mint_cap(TEST_RESERVE_ASSET, 10)
+    let (unbacked_mint_cap) = ReserveConfiguration.get_unbacked_mint_cap(TEST_RESERVE_ASSET)
+    assert unbacked_mint_cap = 10
+    return ()
+end
+
+@external
+func test_eMode_category{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    ReserveConfiguration.set_eMode_category(TEST_RESERVE_ASSET, 10)
+    let (eMode_category) = ReserveConfiguration.get_eMode_category(TEST_RESERVE_ASSET)
+    assert eMode_category = 10
+    return ()
+end
+
+struct Flags:
+    member active : felt
+    member frozen : felt
+    member borrowing_enabled : felt
+    member stable_rate_borrowing_enabled : felt
+    member paused : felt
+end
+
+@external
+func test_get_flags{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    ReserveConfiguration.set_active(TEST_RESERVE_ASSET, 1)
+    ReserveConfiguration.set_frozen(TEST_RESERVE_ASSET, 1)
+    ReserveConfiguration.set_borrowing_enabled(TEST_RESERVE_ASSET, 1)
+    ReserveConfiguration.set_stable_rate_borrowing_enabled(TEST_RESERVE_ASSET, 1)
+    ReserveConfiguration.set_paused(TEST_RESERVE_ASSET, 1)
+    let res = ReserveConfiguration.get_flags(TEST_RESERVE_ASSET)
+    let flags = Flags(res[0], res[1], res[2], res[3], res[4])
+    assert flags = Flags(1, 1, 1, 1, 1)
+    return ()
+end
+
+struct Params:
+    member ltv : felt
+    member liquidation_threshold : felt
+    member liquidation_bonus : felt
+    member decimals : felt
+    member reserve_factor : felt
+    member eMode_category : felt
+end
+
+@external
+func test_params{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    ReserveConfiguration.set_ltv(TEST_RESERVE_ASSET, 10)
+    ReserveConfiguration.set_liquidation_threshold(TEST_RESERVE_ASSET, 20)
+    ReserveConfiguration.set_liquidation_bonus(TEST_RESERVE_ASSET, 30)
+    ReserveConfiguration.set_decimals(TEST_RESERVE_ASSET, 18)
+    ReserveConfiguration.set_reserve_factor(TEST_RESERVE_ASSET, 20)
+    ReserveConfiguration.set_eMode_category(TEST_RESERVE_ASSET, 3)
+    let res = ReserveConfiguration.get_params(TEST_RESERVE_ASSET)
+    let params = Params(res[0], res[1], res[2], res[3], res[4], res[5])
+    assert params = Params(10, 20, 30, 18, 20, 3)
+    return ()
+end
+
+@external
+func test_caps{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    ReserveConfiguration.set_borrow_cap(TEST_RESERVE_ASSET, 1000)
+    ReserveConfiguration.set_supply_cap(TEST_RESERVE_ASSET, 10000)
+    let (borrow_cap, supply_cap) = ReserveConfiguration.get_caps(TEST_RESERVE_ASSET)
+    assert borrow_cap = 1000
+    assert supply_cap = 10000
+    return ()
+end


### PR DESCRIPTION
Implementation of the ReserveConfiguration library. We used multiple storage variables to map reserves to their configurations instead of a bitmap because the gas optimisation in Aave v3's solidity codebase are not relevant in Cairo.