### PR TITLE
Debt token base library

### DIFF
--- a/contracts/protocol/tokenization/base/debt_token_base_library.cairo
+++ b/contracts/protocol/tokenization/base/debt_token_base_library.cairo
@@ -1,4 +1,5 @@
 %lang starknet
+
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.uint256 import Uint256
 from starkware.starknet.common.syscalls import get_caller_address

--- a/contracts/protocol/tokenization/base/debt_token_base_library.cairo
+++ b/contracts/protocol/tokenization/base/debt_token_base_library.cairo
@@ -33,8 +33,11 @@ namespace DebtTokenBase:
 
     # @notice Sets the underlying asset of the debt token
     # @param underlying The underlying asset of the debt token
-    func set_underlying_asset(underlying : felt):
+    func set_underlying_asset{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        underlying : felt
+    ):
         DebtTokenBase_underlying_asset.write(underlying)
+        return ()
     end
 
     # @notice Delegates borrowing power to a user on the specific debt token.
@@ -42,16 +45,20 @@ namespace DebtTokenBase:
     # delegatee cannot force a delegator HF to go below 1)
     # @param delegatee The address receiving the delegated borrowing power
     # @param amount The maximum amount being delegated.
-    func approve_delegation(delegatee : felt, amount : Uint256):
+    func approve_delegation{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        delegatee : felt, amount : Uint256
+    ):
         let (caller) = get_caller_address()
-        _approve_delegation(caller, delegatee, amount)
+        return _approve_delegation(caller, delegatee, amount)
     end
 
     # @notice Returns the borrow allowance of the user
     # @param from_user The user to giving allowance
     # @param to_user The user to give allowance to
     # @return The current allowance of `toUser`
-    func borrow_allowance(from_user : felt, to_user : felt):
+    func borrow_allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        from_user : felt, to_user : felt
+    ) -> (allowance : Uint256):
         let (allowance) = DebtTokenBase_borrow_allowances.read(from_user, to_user)
         return (allowance)
     end

--- a/contracts/protocol/tokenization/base/debt_token_base_library.cairo
+++ b/contracts/protocol/tokenization/base/debt_token_base_library.cairo
@@ -13,9 +13,9 @@ end
 func DebtTokenBase_underlying_asset() -> (asset : felt):
 end
 
-# @dev Emitted on `approveDelegation` and `borrowAllowance
-# @param fromUser The address of the delegator
-# @param toUser The address of the delegatee
+# @dev Emitted on `approve_delegation` and `borrow_allowance`
+# @param from_user The address of the delegator
+# @param to_user The address of the delegatee
 # @param asset The address of the delegated asset
 # @param amount The amount being delegated
 @event

--- a/contracts/protocol/tokenization/base/debt_token_base_library.cairo
+++ b/contracts/protocol/tokenization/base/debt_token_base_library.cairo
@@ -1,0 +1,87 @@
+%lang starknet
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+from starkware.starknet.common.syscalls import get_caller_address
+
+from openzeppelin.security.safemath import SafeUint256
+
+@storage_var
+func DebtTokenBase_borrow_allowances(delegator : felt, delegatee : felt) -> (allowance : Uint256):
+end
+
+@storage_var
+func DebtTokenBase_underlying_asset() -> (asset : felt):
+end
+
+# @dev Emitted on `approveDelegation` and `borrowAllowance
+# @param fromUser The address of the delegator
+# @param toUser The address of the delegatee
+# @param asset The address of the delegated asset
+# @param amount The amount being delegated
+@event
+func BorrowAllowanceDelegated(from_user : felt, to_user : felt, asset : felt, amount : Uint256):
+end
+
+namespace DebtTokenBase:
+    # @notice Returns the underlying asset of the debt token
+    # @return The underlying asset of the debt token
+    func get_underlying_asset{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        ) -> (underlying : felt):
+        let (underlying) = DebtTokenBase_underlying_asset.read()
+        return (underlying)
+    end
+
+    # @notice Sets the underlying asset of the debt token
+    # @param underlying The underlying asset of the debt token
+    func set_underlying_asset(underlying : felt):
+        DebtTokenBase_underlying_asset.write(underlying)
+    end
+
+    # @notice Delegates borrowing power to a user on the specific debt token.
+    # Delegation will still respect the liquidation constraints (even if delegated, a
+    # delegatee cannot force a delegator HF to go below 1)
+    # @param delegatee The address receiving the delegated borrowing power
+    # @param amount The maximum amount being delegated.
+    func approve_delegation(delegatee : felt, amount : Uint256):
+        let (caller) = get_caller_address()
+        _approve_delegation(caller, delegatee, amount)
+    end
+
+    # @notice Returns the borrow allowance of the user
+    # @param from_user The user to giving allowance
+    # @param to_user The user to give allowance to
+    # @return The current allowance of `toUser`
+    func borrow_allowance(from_user : felt, to_user : felt):
+        let (allowance) = DebtTokenBase_borrow_allowances.read(from_user, to_user)
+        return (allowance)
+    end
+
+    # @notice Decreases the borrow allowance of a user on the specific debt token.
+    # @param delegator The address delegating the borrowing power
+    # @param delegatee The address receiving the delegated borrowing power
+    # @param amount The amount to subtract from the current allowance
+    func decrease_borrow_allowance{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+    }(delegator : felt, delegatee : felt, amount : Uint256):
+        let (prev_allowance) = DebtTokenBase_borrow_allowances.read(delegator, delegatee)
+        let (new_allowance) = SafeUint256.sub_le(prev_allowance, amount)
+        DebtTokenBase_borrow_allowances.write(delegator, delegatee, new_allowance)
+        let (underlying) = DebtTokenBase_underlying_asset.read()
+        BorrowAllowanceDelegated.emit(delegator, delegatee, underlying, new_allowance)
+
+        return ()
+    end
+end
+
+# @notice Updates the borrow allowance of a user on the specific debt token.
+# @param delegator The address delegating the borrowing power
+# @param delegatee The address receiving the delegated borrowing power
+# @param amount The allowance amount being delegated.
+func _approve_delegation{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    delegator : felt, delegatee : felt, amount : Uint256
+):
+    DebtTokenBase_borrow_allowances.write(delegator, delegatee, amount)
+    let (underlying) = DebtTokenBase_underlying_asset.read()
+    BorrowAllowanceDelegated.emit(delegator, delegatee, underlying, amount)
+    return ()
+end

--- a/tests/unit_tests/protocol/tokenization/base/test_debt_base_token.cairo
+++ b/tests/unit_tests/protocol/tokenization/base/test_debt_base_token.cairo
@@ -1,0 +1,37 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.uint256 import Uint256
+
+from contracts.protocol.tokenization.base.debt_token_base_library import DebtTokenBase
+from tests.utils.constants import USER_1
+
+@external
+func test_underlying_asset{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    let (underlying) = DebtTokenBase.get_underlying_asset()
+    assert underlying = 0
+    DebtTokenBase.set_underlying_asset(10)
+    let (underlying) = DebtTokenBase.get_underlying_asset()
+    assert underlying = 10
+    return ()
+end
+
+@external
+func test_allowances{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+    alloc_locals
+    let (local caller) = get_caller_address()
+
+    # Initial allowance is 0
+    let (allowance) = DebtTokenBase.borrow_allowance(caller, USER_1)
+    assert allowance = Uint256(0, 0)
+    # Allowance increased to 10
+    DebtTokenBase.approve_delegation(USER_1, Uint256(10, 0))
+    let (allowance) = DebtTokenBase.borrow_allowance(caller, USER_1)
+    assert allowance = Uint256(10, 0)
+    # Allowance decreased to 0
+    DebtTokenBase.decrease_borrow_allowance(caller, USER_1, Uint256(10, 0))
+    let (allowance) = DebtTokenBase.borrow_allowance(caller, USER_1)
+    assert allowance = Uint256(0, 0)
+    return ()
+end


### PR DESCRIPTION
DebtTokenBase library, required for StableDebtToken and VariableDebtToken.
- Manages allowances for a debt token
- Associates the debt token to a specific underlying asset